### PR TITLE
[FSDE-31762] Enhancements for dropdown base component in UxPin

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.js
+++ b/src/components/DropdownMenu/DropdownMenu.js
@@ -142,7 +142,7 @@ export default class DropdownMenu extends React.Component {
         `}
         style={{
           height: `${this.props.height && this.props.scrollItems ? `${this.props.height}px` : ''}`,
-          minHeight: `${this.props.height && !this.props.scrollItems ? `${this.props.height}px` : ''}`,
+          maxHeight: `${this.props.height && !this.props.scrollItems ? `${this.props.height}px` : ''}`,
           minWidth: `${this.props.width ? `${this.props.width}px` : ''}`,
           overflow: `${this.props.height && this.props.scrollItems ? 'auto' : ''}`,
         }}>


### PR DESCRIPTION
This change is in order to automatically get a scrollbar if the dropdown items list exceeds a specified dropdown height. Currently the dropdown height only seems to work in default mode when there are no dropdown items. Implemented these changes as requested by Thomas.